### PR TITLE
既存のテンプレートにWAF・Cloudwatch追加

### DIFF
--- a/CFTN2.yaml
+++ b/CFTN2.yaml
@@ -197,3 +197,56 @@ Resources:
       DefaultActions:
         - Type: forward
           TargetGroupArn: !Ref MyTargetGroup
+
+     # CloudWatch アラーム（CPU使用率）
+  MyCPUAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: EC2HighCPU
+      AlarmDescription: "EC2のCPU使用率が80%以上の場合にアラーム"
+      Namespace: AWS/EC2
+      MetricName: CPUUtilization
+      Dimensions:
+        - Name: InstanceId
+          Value: !Ref MyEC2Instance
+      Statistic: Average
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 80
+      ComparisonOperator: GreaterThanThreshold
+      AlarmActions: []
+      TreatMissingData: notBreaching
+
+     # WAF WebACL
+  MyWebACL:
+    Type: AWS::WAFv2::WebACL
+    Properties:
+      Name: MyWebACL
+      Scope: REGIONAL
+      DefaultAction:
+        Allow: {}
+      VisibilityConfig:
+        SampledRequestsEnabled: true
+        CloudWatchMetricsEnabled: true
+        MetricName: MyWebACL
+      Rules:
+        - Name: AWS-AWSManagedRulesCommonRuleSet
+          Priority: 1
+          OverrideAction:
+            None: {}
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesCommonRuleSet
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: AWSCommonRules
+
+  # WebACL を ALB にアタッチ
+  MyWebACLAssociation:
+    Type: AWS::WAFv2::WebACLAssociation
+    Properties:
+      ResourceArn: !Ref MyALB
+      WebACLArn: !GetAtt MyWebACL.Arn
+    


### PR DESCRIPTION
EC2のCPU使用率アラームを追加しました
WAF WebAClをALBにアタッチしました
追加分以外の変更点は無し
<img width="1899" height="836" alt="image" src="https://github.com/user-attachments/assets/9b252aba-087b-40b9-a4a2-2947e61c8247" />
添付画像はCloudformationスタック作成ログ